### PR TITLE
Move skill config location to skill.file_system

### DIFF
--- a/neon_utils/skills/neon_skill.py
+++ b/neon_utils/skills/neon_skill.py
@@ -20,6 +20,7 @@
 import pathlib
 import pickle
 import json
+import shutil
 import time
 import os
 from copy import deepcopy
@@ -52,7 +53,6 @@ SPEED_MODE_EXTENSION_TIME = {
 }
 DEFAULT_SPEED_MODE = "thoughtful"
 CACHE_TIME_OFFSET = 24*60*60  # seconds in 24 hours
-
 
 
 class NeonSkill(MycroftSkill):
@@ -158,7 +158,10 @@ class NeonSkill(MycroftSkill):
                         default[pref["name"]] = value
 
         # Load or init configuration
-        self.ngi_settings = NGIConfig(self.name, self.root_dir)
+        if os.path.isfile(os.path.join(self.root_dir, f"{self.name}.yml")):
+            LOG.warning(f"Config found in skill directory for {self.name}! Relocating to: {self.file_system}")
+            shutil.move(os.path.join(self.root_dir, f"{self.name}.yml"), self.file_system)
+        self.ngi_settings = NGIConfig(self.name, self.file_system)
 
         # Load any new or updated keys
         try:

--- a/neon_utils/skills/neon_skill.py
+++ b/neon_utils/skills/neon_skill.py
@@ -159,9 +159,9 @@ class NeonSkill(MycroftSkill):
 
         # Load or init configuration
         if os.path.isfile(os.path.join(self.root_dir, f"{self.name}.yml")):
-            LOG.warning(f"Config found in skill directory for {self.name}! Relocating to: {self.file_system}")
-            shutil.move(os.path.join(self.root_dir, f"{self.name}.yml"), self.file_system)
-        self.ngi_settings = NGIConfig(self.name, self.file_system)
+            LOG.warning(f"Config found in skill directory for {self.name}! Relocating to: {self.file_system.path}")
+            shutil.move(os.path.join(self.root_dir, f"{self.name}.yml"), self.file_system.path)
+        self.ngi_settings = NGIConfig(self.name, self.file_system.path)
 
         # Load any new or updated keys
         try:

--- a/version.py
+++ b/version.py
@@ -17,4 +17,4 @@
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"


### PR DESCRIPTION
Move skill configuration to `skill.file_system` to allow OSM updates and match OVOS/Mycroft convention