### PR TITLE
Add method to populate config with Github token

### DIFF
--- a/neon_utils/authentication_utils.py
+++ b/neon_utils/authentication_utils.py
@@ -137,10 +137,11 @@ def populate_amazon_keys_config(aws_keys: dict, config_path: Optional[str] = Non
     if not aws_keys.get("aws_access_key_id") or not aws_keys.get("aws_secret_access_key"):
         raise ValueError
 
-    local_conf = NGIConfig("ngi_local_conf", config_path)
+    local_conf = NGIConfig("ngi_local_conf", config_path, True)
     aws_config = local_conf["tts"]["amazon"]
     aws_config = {**aws_config, **aws_keys}
     local_conf["tts"]["amazon"] = aws_config
+    local_conf.write_changes()
     # TODO: This should move to auth config when available DM
 
 
@@ -152,8 +153,12 @@ def populate_github_token_config(token: str, config_path: Optional[str] = None):
         config_path: Override path to ngi_local_conf
     """
     from neon_utils.configuration_utils import NGIConfig
-    local_conf = NGIConfig("ngi_local_conf", config_path)
+
+    assert token
+
+    local_conf = NGIConfig("ngi_local_conf", config_path, True)
     local_conf["skills"]["neon_token"] = token
+    local_conf.write_changes()
     # TODO: This should move to auth config when available DM
 
 

--- a/neon_utils/authentication_utils.py
+++ b/neon_utils/authentication_utils.py
@@ -144,6 +144,19 @@ def populate_amazon_keys_config(aws_keys: dict, config_path: Optional[str] = Non
     # TODO: This should move to auth config when available DM
 
 
+def populate_github_token_config(token: str, config_path: Optional[str] = None):
+    """
+    Populates configuration with the specified github token for later reference.
+    Args:
+        token: String Github token
+        config_path: Override path to ngi_local_conf
+    """
+    from neon_utils.configuration_utils import NGIConfig
+    local_conf = NGIConfig("ngi_local_conf", config_path)
+    local_conf["skills"]["neon_token"] = token
+    # TODO: This should move to auth config when available DM
+
+
 def repo_is_neon(repo_url: str) -> bool:
     """
     Determines if the specified repository url is part of the NeonGeckoCom org on github

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -34,6 +34,7 @@ from ovos_utils.configuration import read_mycroft_config, LocalConf
 from ruamel.yaml import YAML
 from typing import Optional
 from neon_utils import LOG
+from neon_utils.authentication_utils import find_neon_git_token, populate_github_token_config
 
 
 class NGIConfig:
@@ -649,7 +650,12 @@ def get_neon_skills_config() -> dict:
             LOG.error(e)
             neon_skills["appstore_sync_interval"] = 6.0
     neon_skills["update_interval"] = neon_skills["auto_update_interval"]  # Backwards Compat.
-    # neon_skills["neon_token"]  # TODO: GetPrivateKeys
+    if not neon_skills["neon_token"]:
+        try:
+            neon_skills["neon_token"] = find_neon_git_token()  # TODO: GetPrivateKeys
+            populate_github_token_config(neon_skills["neon_token"])
+        except FileNotFoundError:
+            LOG.warning(f"No Github token found; skills may fail to install!")
     skills_config = {**mycroft_config.get("skills", {}), **neon_skills}
     return skills_config
 

--- a/neon_utils/default_configurations/default_core_conf.yml
+++ b/neon_utils/default_configurations/default_core_conf.yml
@@ -119,6 +119,7 @@ skills:
   repo_url: "https://github.com/MycroftAI/mycroft-skills"
   repo_branch: "18.08"
   data_dir: "~/.neon/msm"
+  neon_token:
 
 audio_parsers:
   blacklist: ["gender"]

--- a/tests/authentication_util_tests.py
+++ b/tests/authentication_util_tests.py
@@ -100,6 +100,20 @@ class AuthUtilTests(unittest.TestCase):
             populate_amazon_keys_config({"aws_access_key_id": "",
                                          "aws_secret_access_key": ""})
 
+    def test_write_github_token(self):
+        import shutil
+        from neon_utils.configuration_utils import get_neon_local_config
+        config_path = os.path.join(ROOT_DIR, "configuration")
+        old_local_conf = os.path.join(config_path, "old_local_conf.yml")
+        ngi_local_conf = os.path.join(config_path, "ngi_local_conf.yml")
+        shutil.copy(ngi_local_conf, old_local_conf)
+        token = "TOKEN"
+        local_config = get_neon_local_config(config_path)
+        self.assertIsNone(local_config["skills"]["neon_token"])
+        populate_github_token_config(token, config_path)
+        self.assertEqual(local_config["skills"]["neon_token"], token)
+        shutil.move(old_local_conf, ngi_local_conf)
+
     def test_repo_is_neon_valid(self):
         self.assertTrue(repo_is_neon("http://github.com/NeonGeckoCom/alerts.neon"))
         self.assertTrue(repo_is_neon("https://github.com/NeonGeckoCom/caffeinewiz.neon"))

--- a/tests/configuration_util_tests.py
+++ b/tests/configuration_util_tests.py
@@ -397,6 +397,7 @@ class ConfigurationUtilTests(unittest.TestCase):
         self.assertIsInstance(config["install_essential"], bool)
         self.assertIn("default_skills", config)
         self.assertIn("essential_skills", config)
+        self.assertIn("neon_token", config)
 
         self.assertEqual(config["update_interval"], config["auto_update_interval"])  # Backwards Compat.
         self.assertIsInstance(config["directory"], str)

--- a/version.py
+++ b/version.py
@@ -17,4 +17,4 @@
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"


### PR DESCRIPTION
Adds method for populating Github token similar to AWS keys with unit tests
Update `get_neon_local_config` to return `NGIConfig` objects instead of `dict`s for tracking changes (match `get_neon_user_config`)