### PR TITLE
Suppress filelock logs

### DIFF
--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -16,13 +16,15 @@
 # Specialized conversational reconveyance options from Conversation Processing Intelligence Corp.
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
-import re
 
+import logging
+import re
 import json
 import os
 import sys
 import shutil
 import sysconfig
+
 from copy import deepcopy
 from os.path import *
 from collections.abc import MutableMapping
@@ -35,6 +37,8 @@ from ruamel.yaml import YAML
 from typing import Optional
 from neon_utils import LOG
 from neon_utils.authentication_utils import find_neon_git_token, populate_github_token_config
+
+logging.getLogger("filelock").setLevel(logging.WARNING)
 
 
 class NGIConfig:


### PR DESCRIPTION
Prevent `filelock` from spamming logs on config load