### PR TITLE
Fix get_mq_response message ACK

### DIFF
--- a/neon_utils/mq_utils.py
+++ b/neon_utils/mq_utils.py
@@ -17,14 +17,14 @@
 # US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
 # China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
 
-from threading import Event
-from time import sleep
+import uuid
 
+from threading import Event
 from pika.exceptions import ProbableAccessDeniedError
+from neon_mq_connector.connector import MQConnector, ConsumerThread
 
 from neon_utils import LOG
 from neon_utils.socket_utils import b64_to_dict
-from neon_mq_connector.connector import MQConnector, ConsumerThread
 from neon_utils.configuration_utils import get_neon_local_config
 
 
@@ -39,16 +39,19 @@ class NeonMQHandler(MQConnector):
         super().stop_consumers()
 
 
-def get_mq_response(vhost: str, request_data: dict, target_queue: str, response_queue: str, timeout: int = 30) -> dict:
+def get_mq_response(vhost: str, request_data: dict, target_queue: str,
+                    response_queue: str = None, timeout: int = 30) -> dict:
     """
     Sends a request to the MQ server and returns the response.
     :param vhost: vhost to target
     :param request_data: data to post to target_queue
     :param target_queue: queue to post request to
-    :param response_queue: queue to monitor for a response
+    :param response_queue: optional queue to monitor for a response. Generally should be blank
     :param timeout: time in seconds to wait for a response before timing out
     :return: response to request
     """
+    response_queue = response_queue or uuid.uuid4().hex
+
     response_event = Event()
     message_id = None
     response_data = dict()
@@ -83,6 +86,7 @@ def get_mq_response(vhost: str, request_data: dict, target_queue: str, response_
                                               neon_api_mq_handler.vhost, response_queue, handle_mq_response,
                                               auto_ack=False)
         neon_api_mq_handler.run_consumers()
+        request_data['routing_key'] = response_queue
         message_id = neon_api_mq_handler.emit_mq_message(connection=neon_api_mq_handler.connection,
                                                          queue=target_queue,
                                                          request_data=request_data,
@@ -90,7 +94,7 @@ def get_mq_response(vhost: str, request_data: dict, target_queue: str, response_
         LOG.debug(f'Sent request: {request_data}')
         response_event.wait(timeout)
         if not response_event.is_set():
-            LOG.error(f"Timeout waiting for response to: {message_id}")
+            LOG.error(f"Timeout waiting for response to: {message_id} on {response_queue}")
         neon_api_mq_handler.stop_consumers()
     except ProbableAccessDeniedError:
         raise ValueError(f"{vhost} is not a valid endpoint for {config.get('users').get('mq_handler').get('user')}")

--- a/neon_utils/mq_utils.py
+++ b/neon_utils/mq_utils.py
@@ -69,10 +69,7 @@ def get_mq_response(vhost: str, request_data: dict, target_queue: str, response_
             LOG.warning(f"Ignoring response to message_id: {api_output_msg_id}")
         if api_output_msg_id == message_id:
             LOG.debug(f'MQ output: {api_output}')
-            try:
-                channel.basic_ack(delivery_tag=method.delivery_tag)
-            except Exception as e:
-                LOG.error(e)
+            channel.basic_ack(delivery_tag=method.delivery_tag)
             response_data.update(api_output)
             response_event.set()
 
@@ -86,7 +83,8 @@ def get_mq_response(vhost: str, request_data: dict, target_queue: str, response_
             raise ConnectionError("MQ Connection not established.")
 
         neon_api_mq_handler.register_consumer('neon_output_handler',
-                                              neon_api_mq_handler.vhost, response_queue, handle_mq_response)
+                                              neon_api_mq_handler.vhost, response_queue, handle_mq_response,
+                                              auto_ack=False)
         neon_api_mq_handler.run_consumers()
         message_id = neon_api_mq_handler.emit_mq_message(connection=neon_api_mq_handler.connection,
                                                          queue=target_queue,

--- a/neon_utils/mq_utils.py
+++ b/neon_utils/mq_utils.py
@@ -34,11 +34,6 @@ class NeonMQHandler(MQConnector):
         self.vhost = vhost
         self.connection = self.create_mq_connection(vhost=vhost)
 
-    def run_consumers(self):
-        super(NeonMQHandler, self).run_consumers(names=('neon_output_handler',), daemon=True)
-        self.consumers['neon_output_handler']._started.wait()
-        # TODO: Waiting for consumers should be handled in NeonMQHandler DM
-
 
 def get_mq_response(vhost: str, request_data: dict, target_queue: str, response_queue: str, timeout: int = 30) -> dict:
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,5 @@ langdetect~=1.0.8
 translate
 boto3
 ovos_utils>=0.0.6
-#neon_mq_connector>=0.0.5a5
-neon_mq_connector @ git+https://github.com/neondaniel/neon_mq_connector@FEAT_MessageAck
+neon_mq_connector>=0.1.1a0
 combo-lock~=0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ langdetect~=1.0.8
 translate
 boto3
 ovos_utils>=0.0.6
-neon_mq_connector>=0.0.5a5
-
+#neon_mq_connector>=0.0.5a5
+neon_mq_connector @ git+https://github.com/neondaniel/neon_mq_connector@FEAT_MessageAck
 combo-lock~=0.1

--- a/tests/mq_util_tests.py
+++ b/tests/mq_util_tests.py
@@ -20,11 +20,11 @@
 import os
 import sys
 import unittest
+
 import pika
 
 from multiprocessing import Process
-from time import time, sleep
-from neon_mq_connector.connector import MQConnector, ConsumerThread
+from time import time
 
 from neon_utils.socket_utils import *
 
@@ -54,6 +54,7 @@ class TestMQConnector(MQConnector):
                               routing_key=OUTPUT_CHANNEL,
                               body=response,
                               properties=pika.BasicProperties(expiration='1000'))
+        channel.basic_ack(delivery_tag=method.delivery_tag)
 
 
 class MqUtilTests(unittest.TestCase):
@@ -64,7 +65,7 @@ class MqUtilTests(unittest.TestCase):
                                              service_name="mq_handler",
                                              vhost=vhost)
         cls.test_connector.register_consumer("neon_utils_test", vhost, INPUT_CHANNEL,
-                                             cls.test_connector.respond)
+                                             cls.test_connector.respond, auto_ack=False)
         cls.test_connector.run_consumers()
         sleep(5)
 

--- a/tests/mq_util_tests.py
+++ b/tests/mq_util_tests.py
@@ -23,7 +23,7 @@ import unittest
 
 import pika
 
-from multiprocessing import Process
+from threading import Thread
 from time import time
 
 from neon_utils.socket_utils import *
@@ -106,13 +106,14 @@ class MqUtilTests(unittest.TestCase):
             responses[name] = {'success': True}
 
         for i in range(8):
-            p = Process(target=check_response, args=(str(i),))
+            p = Thread(target=check_response, args=(str(i),))
             p.start()
             processes.append(p)
 
         for p in processes:
             p.join(30)
 
+        self.assertEqual(len(processes), len(responses))
         for resp in responses.values():
             self.assertTrue(resp['success'], resp.get('reason'))
 


### PR DESCRIPTION
Makes get_mq_response manually ACK messages to prevent consuming messages intended for other clients