### PR TITLE
Add core 'language' settings

### DIFF
--- a/tests/configuration/local_conf_no_language.yml
+++ b/tests/configuration/local_conf_no_language.yml
@@ -9,7 +9,6 @@ prefFlags:
   metrics: False
   saveAudio: False
   saveText: True
-  # TODO: These should go somewhere in HAL/Enclosure
   localGui: True
   guiEvents: True
 
@@ -37,7 +36,6 @@ devVars:
   defaultVolume: 60
   defaultMicVolume: 100
   installUser:
-  # TODO: Depreciate installUser
 
 gestures:
   clapThreshold: 10.0e10
@@ -64,7 +62,6 @@ websocket:
   ssl_key:
 
 gui:
-  # TODO: This should be built so lang, enclosure are read from other places
   # Host information for the gui server
   lang: en-us
   enclosure: generic
@@ -144,13 +141,8 @@ tts:
   }
 stt:
   module: google_cloud_streaming
-
-language:
-  boost: False
-  core_lang: en-us
-  translation_module: libretranslate_plug
-  detection_module: libretranslate_detection_plug
-  libretranslate: {"libretranslate_host": "https://translate.neon.ai:5000"}
+  translation_module: old_translate_module
+  detection_module: old_detection_module
 
 logs:
   blacklist: ["enclosure.mouth.viseme", "enclosure.mouth.display"]

--- a/tests/configuration_util_tests.py
+++ b/tests/configuration_util_tests.py
@@ -373,6 +373,7 @@ class ConfigurationUtilTests(unittest.TestCase):
         self.assertIn("detection_module", config)
         self.assertIn("translation_module", config)
         self.assertIn("boost", config)
+        self.assertIsInstance(config["libretranslate"], dict)
 
     def test_get_client_config(self):
         config = get_neon_client_config()
@@ -607,6 +608,20 @@ class ConfigurationUtilTests(unittest.TestCase):
         local_config = get_neon_local_config(CONFIG_PATH)
         self.assertEqual(local_config["tts"]["mozilla_remote"], {"url": "http://something.somewhere"})
         self.assertEqual(local_config["stt"]["some_module"], {"key": "value"})
+        self.assertIn("dirVars", local_config.content.keys())
+        shutil.move(bak_local_conf, ngi_local_conf)
+
+    def test_move_language_config(self):
+        bak_local_conf = os.path.join(CONFIG_PATH, "ngi_local_conf.bak")
+        ngi_local_conf = os.path.join(CONFIG_PATH, "ngi_local_conf.yml")
+        ngi_test_conf = os.path.join(CONFIG_PATH, "local_conf_no_language.yml")
+
+        shutil.move(ngi_local_conf, bak_local_conf)
+        shutil.copy(ngi_test_conf, ngi_local_conf)
+        local_config = get_neon_local_config(CONFIG_PATH)
+        self.assertEqual(local_config["language"]["translation_module"], "old_translate_module")
+        self.assertEqual(local_config["language"]["detection_module"], "old_detection_module")
+        self.assertIsInstance(local_config["language"]["libretranslate"], dict)
         self.assertIn("dirVars", local_config.content.keys())
         shutil.move(bak_local_conf, ngi_local_conf)
 


### PR DESCRIPTION
Move translation/detection module spec to 'language' in local config
Add boost, core_lang, and libretranslate default config values
Handle moving config from stt to language with unit tests