### PR TITLE
Refactor MQ calls from `get_mq_response` to `send_mq_request`

### DIFF
--- a/neon_utils/ccl_utils.py
+++ b/neon_utils/ccl_utils.py
@@ -30,7 +30,7 @@ try:
     from neon_script_parser import ScriptParser
 except ImportError:
     ScriptParser = None
-    from neon_utils.mq_utils import get_mq_response
+    from neon_utils.mq_utils import get_mq_response, send_mq_request
 
 
 def parse_nct_to_ncs(nct_file_path: str, ncs_file_path: Optional[str] = None,
@@ -136,5 +136,5 @@ def load_ncs_file(ncs_file_path: str) -> dict:
 def get_compiled_script_via_mq(text: str, meta: Optional[dict]) -> str:
     data = {"text": text,
             "meta": meta}
-    resp = get_mq_response("/neon_script_parser", data, "neon_script_parser_input", timeout=45)
+    resp = send_mq_request("/neon_script_parser", data, "neon_script_parser_input", timeout=45)
     return resp["parsed_file"]

--- a/neon_utils/service_apis/__init__.py
+++ b/neon_utils/service_apis/__init__.py
@@ -19,7 +19,7 @@
 
 from enum import Enum
 from neon_utils.configuration_utils import get_neon_auth_config
-from neon_utils.mq_utils import get_mq_response
+from neon_utils.mq_utils import send_mq_request
 
 AUTH_CONFIG = get_neon_auth_config()
 
@@ -53,7 +53,7 @@ def request_neon_api(api: NeonAPI, query_params: dict, timeout: int = 30) -> dic
         raise TypeError(f"Expected dict, got: {query_params}")
 
     request_data = {**query_params, **{"service": str(api)}}
-    response = get_mq_response("/neon_api", request_data, "neon_api_input", "neon_api_output", timeout)
+    response = send_mq_request("/neon_api", request_data, "neon_api_input", "neon_api_output", timeout)
     return response or {"status_code": 401,
                         "content": f"Neon API failed to give a response within {timeout} seconds",
                         "encoding": None}


### PR DESCRIPTION
#203 Introduced the new method but did not update calls. Objective is to phase out support for `get_mq_response` and use the new `send_mq_request` method that has a different signature to make responses optional