### PR TITLE
Ensure config and cache directories exist

### DIFF
--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -469,6 +469,8 @@ def get_config_dir():
         return legacy_path
 
     default_path = expanduser("~/.local/share/neon")
+    if not isdir(legacy_path):
+        os.makedirs(legacy_path)
     # LOG.info(f"System packaged core found! Using default configuration at {default_path}")
     return default_path
 

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -441,7 +441,8 @@ def _get_legacy_config_dir(sys_path: Optional[list] = None) -> Optional[str]:
 
 def get_config_dir():
     """
-    Get a default directory in which to find configuration files
+    Get a default directory in which to find configuration files,
+    creating it if it doesn't exist.
     Returns: Path to configuration or else default
     """
     # Check envvar spec path
@@ -462,6 +463,8 @@ def get_config_dir():
     # Check for legacy path spec
     legacy_path = _get_legacy_config_dir()
     if legacy_path:
+        if not isdir(legacy_path):
+            os.makedirs(legacy_path)
         # LOG.warning(f"Legacy Config Path Found: {legacy_path}")
         return legacy_path
 

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -469,8 +469,8 @@ def get_config_dir():
         return legacy_path
 
     default_path = expanduser("~/.local/share/neon")
-    if not isdir(legacy_path):
-        os.makedirs(legacy_path)
+    if not isdir(default_path):
+        os.makedirs(default_path)
     # LOG.info(f"System packaged core found! Using default configuration at {default_path}")
     return default_path
 

--- a/neon_utils/skills/neon_skill.py
+++ b/neon_utils/skills/neon_skill.py
@@ -80,6 +80,9 @@ class NeonSkill(MycroftSkill):
         super(NeonSkill, self).__init__(name, bus, use_settings)
         self.cache_loc = os.path.expanduser(self.local_config.get('dirVars', {}).get('cacheDir') or
                                             "~/.local/share/neon/cache")
+        if not os.path.isdir(self.cache_loc):
+            LOG.debug(f"Creating cache directory: {self.cache_loc}")
+            os.makedirs(self.cache_loc, exist_ok=True)
         self.lru_cache = LRUCache()
 
         # TODO: Depreciate these references, signal use is discouraged DM

--- a/tests/configuration_util_tests.py
+++ b/tests/configuration_util_tests.py
@@ -325,6 +325,7 @@ class ConfigurationUtilTests(unittest.TestCase):
         self.assertIsNotNone(os.getenv("NEON_CONFIG_PATH"))
         config_path = get_config_dir()
         self.assertEqual(config_path, os.path.expanduser("~/"))
+        self.assertTrue(os.path.isdir(config_path))
         os.environ.pop("NEON_CONFIG_PATH")
         self.assertIsNone(os.getenv("NEON_CONFIG_PATH"))
 


### PR DESCRIPTION
In Docker implementations, default config/cache paths are not guaranteed to exist; adds conditional creation of directories in config/skills