### PR TITLE
Minor changes to `write_mycroft_compatible_config`

### DIFF
--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -1179,8 +1179,17 @@ def write_mycroft_compatible_config(file_to_write: str = "~/.mycroft/mycroft.con
     """
     configuration = get_mycroft_compatible_config()
     file_path = os.path.expanduser(file_to_write)
-    if not isdir(dirname(file_path)):
+
+    if isfile(file_path):
+        with open(file_path, 'r') as f:
+            disk_config = json.load(f)
+        if disk_config == configuration:
+            LOG.debug(f"Configuration already up to date")
+            return file_path
+        LOG.warning(f"File exists and will be overwritten: {file_to_write}")
+    elif not isdir(dirname(file_path)):
         os.makedirs(dirname(file_path))
+
     with create_lock(file_path):
         with open(file_path, 'w') as f:
             json.dump(configuration, f, indent=4)

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -1171,12 +1171,14 @@ def get_mycroft_compatible_config(mycroft_only=False) -> dict:
     return default_config
 
 
-def write_mycroft_compatible_config(file_to_write: str = "~/.mycroft/mycroft.conf") -> str:
+def write_mycroft_compatible_config(file_to_write: str = None) -> str:
     """
-    Generates a mycroft-compatible configuration and writes it to the specified file
+    Generates a mycroft-like configuration and writes it to the specified file
+    NOTE: This is potentially destructive and will overwrite existing config
     :param file_to_write: config file to write out
     :return: path to written config file
     """
+    file_to_write = file_to_write or "~/.mycroft/mycroft.conf"
     configuration = get_mycroft_compatible_config()
     file_path = os.path.expanduser(file_to_write)
 


### PR DESCRIPTION
Better handling of default path
Improved logging and docstrings warning file overwrites
Prevent writing unchanged config for minor efficiency