### PR TITLE
Legacy Config Migration

### DIFF
--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -464,7 +464,6 @@ def _init_ovos_conf(name: str):
         "submodule_mappings": {}
     }
 
-    from ovos_utils.xdg_utils import xdg_config_home
     ovos_path = join(xdg_config_home(), "OpenVoiceOS", "ovos.conf")
     if isfile(ovos_path):
         try:
@@ -507,7 +506,7 @@ def _init_ovos_conf(name: str):
     # imports within ovos_config and mycroft.configuration
     import ovos_config
     importlib.reload(ovos_config.locations)
-    from ovos_utils.configuration import get_ovos_config
+    from ovos_config.meta import get_ovos_config
     ovos_conf = get_ovos_config()  # Load the full stack for /etc overrides
     if ovos_conf["module_overrides"]["neon_core"].get("default_config_path"):
         ovos_config.locations.DEFAULT_CONFIG = \
@@ -633,7 +632,6 @@ def get_config_dir():
     creating it if it doesn't exist.
     Returns: Path to configuration or else default
     """
-    from ovos_utils.xdg_utils import xdg_config_home
     config_path = join(xdg_config_home(), "neon")
     LOG.debug(config_path)
     if not isdir(config_path):
@@ -781,7 +779,7 @@ def get_user_config_from_mycroft_conf(user_config: dict = None) -> dict:
     Populates user_config with values from mycroft.conf
     :returns: dict modified or created user config
     """
-    from ovos_utils.configuration import MycroftUserConfig
+    from ovos_config.models import MycroftUserConfig
     user_config = user_config or \
         deepcopy(NGIConfig("default_user_conf",
                            os.path.join(os.path.dirname(__file__),
@@ -1463,14 +1461,14 @@ def _safe_mycroft_config() -> dict:
     Returns:
         dict mycroft configuration
     """
-    from ovos_utils.configuration import read_mycroft_config
-    config = read_mycroft_config()
+    from ovos_config.config import Configuration
+    config = Configuration()
     return dict(config)
 
 
 def _get_neon_yaml_config() -> dict:
-    from ovos_utils.configuration import get_ovos_config, \
-        get_xdg_config_save_path
+    from ovos_config.meta import get_ovos_config
+    from ovos_config.locations import get_xdg_config_save_path
     from ovos_utils.json_helper import merge_dict
 
     with open(get_ovos_config()["default_config_path"]) as f:

--- a/tests/configuration/unwritable_path/ngi_local_conf.yml
+++ b/tests/configuration/unwritable_path/ngi_local_conf.yml
@@ -1,0 +1,36 @@
+prefFlags:
+  codeSource: git
+  devMode: true
+  autoStart: true
+  autoUpdate: false
+  # Flag if gui is installed locally
+  localGui: true
+  # Flag if enclosure service should run to generate gui events
+  guiEvents: true
+  notifyRelease: true
+  showDemo: false
+  optDiags: false
+  metrics: false
+
+devVars:
+  devName: NeonTestRunner
+  devType: generic
+  # generic, server, pi, neonK, neonX, neonPi, neonAlpha, neonU
+  version: 2021-02-26-185606
+  installUser: neon
+  likesLastUpdate:
+  caffeineUpdate: ''
+  touchDev:
+  micDev:
+  camDev: 0
+  soundDev:
+  clapThreshold: 10.0e10
+  defaultVolume: 60
+  defaultMicVolume: 100
+MQ:
+  server: 2022.us
+  port: 25672
+  users:
+    mq_handler:
+      user: 'neon_api_utils'
+      password: 'Klatchat2021'


### PR DESCRIPTION
Updates `init_config_dir` to handle migration of old-style yml config to new `neon.yaml` spec
Should resolve issue with Kubernetes containers running with old config