### PR TITLE
Improve native language support in skills

### DIFF
--- a/neon_utils/parse_utils.py
+++ b/neon_utils/parse_utils.py
@@ -228,3 +228,28 @@ def transliteration(transcription: str, text: str, lang: str) -> (str, str):
             return text
     else:
         return text
+
+
+def get_full_lang_code(lang: str) -> str:
+    """
+    Get a BCP 47 lang code for an input ISO 639-2 code
+    """
+    if '-' in lang:
+        return lang
+    known_defaults = {
+        'uk': 'uk-ua',
+        'ja': 'ja-jp',
+        'bg': 'bg-bg',
+        'fi': 'fi-fi',
+        'ga': 'ga-ie'
+    }
+    from lingua_franca import get_full_lang_code
+    try:
+        full_code = get_full_lang_code(lang)
+    except AttributeError:
+        full_code = None
+    full_code = full_code if full_code and full_code != lang else \
+        known_defaults.get(lang, lang)
+    if '-' not in full_code:
+        LOG.warning(f"No full code resolved for {lang}")
+    return full_code

--- a/neon_utils/skills/mycroft_skill.py
+++ b/neon_utils/skills/mycroft_skill.py
@@ -36,6 +36,7 @@ from typing import Optional
 from json_database import JsonStorage
 from mycroft_bus_client.message import Message
 
+from neon_utils.parse_utils import get_full_lang_code
 from neon_utils.signal_utils import wait_for_signal_clear
 from neon_utils.skills.skill_gui import SkillGUI
 from neon_utils.logger import LOG
@@ -63,8 +64,18 @@ class PatchedMycroftSkill(MycroftSkill):
         return get_mycroft_compatible_location(get_user_prefs()["location"])
 
     @property
+    def _core_lang(self):
+        return self.config_core.get('language', {}).get("internal") or \
+               super()._core_lang
+
+    @property
     def _secondary_langs(self):
-        return get_user_prefs()["speech"]["alt_languages"]
+        if self.config_core.get('language', {}).get('supported_langs'):
+            full_langs = (get_full_lang_code(lang) for lang in
+                          self.config_core['language']['supported_langs'])
+            core_lang = self._core_lang
+            return [lang for lang in full_langs if lang != core_lang]
+        return super()._secondary_langs
 
     def _init_settings(self):
         """
@@ -188,8 +199,17 @@ class PatchedMycroftSkill(MycroftSkill):
         """
         data = data or {}
         LOG.debug(f"data={data}")
-        if self.dialog_renderer:  # TODO: Pass index (0) here to use non-random responses DM
-            to_speak = self.dialog_renderer.render(key, data)
+        user = get_user_prefs(message)
+        requested_response_language = user['speech']['tts_language']
+        original_lang = str(message.data.get('lang'))
+        message.data['lang'] = requested_response_language
+        if not self.dialog_renderer:
+            message.data['lang'] = original_lang
+        if self.dialog_renderer:
+            if user['response_mode'].get('limit_dialog'):
+                to_speak = self.dialog_renderer.render(key, data, 0)
+            else:
+                to_speak = self.dialog_renderer.render(key, data)
         else:
             to_speak = key
         self.speak(to_speak,

--- a/tests/parse_util_tests.py
+++ b/tests/parse_util_tests.py
@@ -168,6 +168,17 @@ class ParseUtilTests(unittest.TestCase):
         tagged_with_exclusion = format_speak_tags("Don't<speak>Speak This.</speak>But Not this.", False)
         self.assertEqual(tagged_with_exclusion, valid_output)
 
+    def test_get_full_lang_code(self):
+        from neon_utils.parse_utils import get_full_lang_code
+        self.assertEqual(get_full_lang_code('en'), 'en-us')
+        self.assertEqual(get_full_lang_code('ga'), 'ga-ie')
+        self.assertEqual(get_full_lang_code(''), '')
+        self.assertEqual(get_full_lang_code('en-AU'), 'en-AU')
+        self.assertEqual(get_full_lang_code('not-valid'), 'not-valid')
+        self.assertEqual(get_full_lang_code('invalid'), 'invalid')
+        with self.assertRaises(TypeError):
+            get_full_lang_code(None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix `_secondary_langs` property to use globally configured supported languages
Update `speak_dialog` to use translated dialogs when available for "primary response"
Add `parse_utils.get_full_lang_code` to patch languages missing from LF method