### PR TITLE
Force recreation of Configuration object after building ovos.conf

### DIFF
--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -519,6 +519,7 @@ def _init_ovos_conf(name: str):
         ovos_config.locations.DEFAULT_CONFIG = \
             ovos_conf["module_overrides"]["neon_core"]["default_config_path"]
 
+    del ovos_config.config.Configuration
     importlib.reload(ovos_config.config)
     importlib.reload(ovos_config)
     import ovos_config.models

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -515,12 +515,16 @@ def _init_ovos_conf(name: str):
     importlib.reload(ovos_config.locations)
     from ovos_config.meta import get_ovos_config
     ovos_conf = get_ovos_config()  # Load the full stack for /etc overrides
-    if ovos_conf["module_overrides"]["neon_core"].get("default_config_path"):
+    if ovos_conf["module_overrides"]["neon_core"].get("default_config_path") \
+        and ovos_config.locations.DEFAULT_CONFIG != \
+            ovos_conf["module_overrides"]["neon_core"]["default_config_path"]:
         ovos_config.locations.DEFAULT_CONFIG = \
             ovos_conf["module_overrides"]["neon_core"]["default_config_path"]
 
-    del ovos_config.config.Configuration
-    del ovos_config.Configuration
+        # Default config changed, remove any cached configuration
+        del ovos_config.config.Configuration
+        del ovos_config.Configuration
+
     import ovos_config.models
     importlib.reload(ovos_config.models)
     importlib.reload(ovos_config.config)

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -520,15 +520,17 @@ def _init_ovos_conf(name: str):
             ovos_conf["module_overrides"]["neon_core"]["default_config_path"]
 
     del ovos_config.config.Configuration
-    importlib.reload(ovos_config.config)
-    importlib.reload(ovos_config)
+    del ovos_config.Configuration
     import ovos_config.models
     importlib.reload(ovos_config.models)
+    importlib.reload(ovos_config.config)
+    importlib.reload(ovos_config)
 
     try:
         import mycroft.configuration
         import mycroft.configuration.locations
         import mycroft.configuration.config
+        del mycroft.configuration.Configuration
         importlib.reload(mycroft.configuration.locations)
         importlib.reload(mycroft.configuration.config)
         importlib.reload(mycroft.configuration)

--- a/tests/configuration/neon_core/configuration/neon.yaml
+++ b/tests/configuration/neon_core/configuration/neon.yaml
@@ -1,0 +1,1 @@
+default_config: True

--- a/tests/configuration_util_tests.py
+++ b/tests/configuration_util_tests.py
@@ -842,6 +842,11 @@ class ConfigurationUtilTests(unittest.TestCase):
         self.assertEqual(ovos_config.config.Configuration.default.path,
                          ovos_config.DEFAULT_CONFIG)
 
+        # Test default config path
+        from ovos_config.meta import get_ovos_config
+        self.assertEqual(ovos_config.config.Configuration.default.path,
+                         get_ovos_config()['default_config_path'])
+
         os.environ.pop("XDG_CONFIG_HOME")
         shutil.rmtree(test_config_dir)
         importlib.reload(ovos_config.locations)

--- a/tests/configuration_util_tests.py
+++ b/tests/configuration_util_tests.py
@@ -851,10 +851,13 @@ class ConfigurationUtilTests(unittest.TestCase):
         self.assertEqual(get_ovos_config()['default_config_path'],
                          join(default_config, "configuration", "neon.yaml"))
 
+        # Cleanup configuration and force reload of pre-test defaults
         os.environ.pop("XDG_CONFIG_HOME")
         shutil.rmtree(test_config_dir)
-        importlib.reload(ovos_config.meta)
+        del ovos_config.config.Configuration
         importlib.reload(ovos_config.locations)
+        importlib.reload(ovos_config.models)
+        importlib.reload(ovos_config.config)
 
     def test_validate_config_env(self):
         from neon_utils.configuration_utils import _validate_config_env

--- a/tests/configuration_util_tests.py
+++ b/tests/configuration_util_tests.py
@@ -853,6 +853,7 @@ class ConfigurationUtilTests(unittest.TestCase):
 
         os.environ.pop("XDG_CONFIG_HOME")
         shutil.rmtree(test_config_dir)
+        importlib.reload(ovos_config.meta)
         importlib.reload(ovos_config.locations)
 
     def test_validate_config_env(self):


### PR DESCRIPTION
Patches bug introduced in #366 
Adds unit test case for modified default config directory
These changes also mean calls to `init_config_dir` after a reference to `ovos_config` will force reloading of loaded Configuration