### PR TITLE
Add support for event-based `wait_while_speaking`

### DIFF
--- a/neon_utils/skills/mycroft_skill.py
+++ b/neon_utils/skills/mycroft_skill.py
@@ -165,14 +165,22 @@ class PatchedMycroftSkill(MycroftSkill):
                                              "source": ["audio"]})
                 LOG.debug(f"Skill speak! {data}")
             LOG.debug(msg_to_emit.msg_type)
-            self.bus.emit(msg_to_emit)
+
+            if wait and self.config_core.get('signal',
+                                             {}).get('speak_bus_api'):
+                msg_to_emit.data['speak_ident'] = str(time.time())
+                self.bus.wait_for_response(msg_to_emit,
+                                           msg_to_emit.data['speak_ident'],
+                                           self._speak_timeout)
+            else:
+                self.bus.emit(msg_to_emit)
+                if wait and not message.context.get("klat_data"):
+                    LOG.debug("Using legacy isSpeaking signal")
+                    wait_for_signal_clear('isSpeaking')
+
         else:
             LOG.warning("Null utterance passed to speak")
             LOG.warning(f"{self.name} | message={message}")
-
-        if wait and not message.context.get("klat_data"):
-            # TODO: Refactor to wait for event emit
-            wait_for_signal_clear('isSpeaking')
 
     @resolve_message
     def speak_dialog(self, key, data=None, expect_response=False, wait=False,
@@ -266,10 +274,8 @@ class PatchedMycroftSkill(MycroftSkill):
             dialog = self.dialog_renderer.render(dialog, data)
 
         if dialog:
-            self.speak(dialog, expect_response=True, wait=False,
-                       message=message, private=True)
-        else:
-            self.bus.emit(message.forward('mycroft.mic.listen'))
+            self.speak(dialog, wait=True, message=message, private=True)
+        self.bus.emit(message.forward('mycroft.mic.listen'))
         return self._wait_response(is_cancel, validator, on_fail_fn,
                                    num_retries, message, user)
 
@@ -329,17 +335,6 @@ class PatchedMycroftSkill(MycroftSkill):
             str: user's response or None on a timeout
         """
         event = Event()
-        finished_speaking = Event()
-
-        # TODO: get_response should be event-based instead of signals
-        def _wait_while_speaking():
-            if wait_for_signal_clear("isSpeaking", self._speak_timeout):
-                LOG.error("Still speaking after 30s")
-            else:
-                # Handle a second prompt after ended speech
-                time.sleep(0.5)
-                wait_for_signal_clear("isSpeaking", self._speak_timeout)
-            finished_speaking.set()
 
         def converse(message):
             resp_user = get_message_user(message) or "local"
@@ -347,7 +342,6 @@ class PatchedMycroftSkill(MycroftSkill):
                 utterances = message.data.get("utterances")
                 converse.response = utterances[0] if utterances else None
                 event.set()
-                finished_speaking.set()
                 LOG.info(f"Got response: {converse.response}")
                 return True
             LOG.debug(f"Ignoring input from: {resp_user}")
@@ -359,11 +353,6 @@ class PatchedMycroftSkill(MycroftSkill):
         default_converse = self.converse
         self.converse = converse
 
-        t = Thread(target=_wait_while_speaking, daemon=True)
-        t.start()
-
-        finished_speaking.wait(self._speak_timeout)
-        t.join(0)
         if not event.wait(self._get_response_timeout):
             LOG.warning("Timed out waiting for user response")
         self.converse = default_converse

--- a/neon_utils/skills/mycroft_skill.py
+++ b/neon_utils/skills/mycroft_skill.py
@@ -36,7 +36,7 @@ from typing import Optional
 from json_database import JsonStorage
 from mycroft_bus_client.message import Message
 
-from neon_utils.signal_utils import wait_for_signal_clear
+from neon_utils.signal_utils import wait_for_signal_clear, check_for_signal
 from neon_utils.skills.skill_gui import SkillGUI
 from neon_utils.logger import LOG
 from neon_utils.message_utils import get_message_user, dig_for_message, resolve_message
@@ -166,8 +166,7 @@ class PatchedMycroftSkill(MycroftSkill):
                 LOG.debug(f"Skill speak! {data}")
             LOG.debug(msg_to_emit.msg_type)
 
-            if wait and self.config_core.get('signal',
-                                             {}).get('speak_bus_api'):
+            if wait and check_for_signal("neon_speak_api"):
                 msg_to_emit.data['speak_ident'] = str(time.time())
                 self.bus.wait_for_response(msg_to_emit,
                                            msg_to_emit.data['speak_ident'],

--- a/neon_utils/skills/mycroft_skill.py
+++ b/neon_utils/skills/mycroft_skill.py
@@ -166,7 +166,7 @@ class PatchedMycroftSkill(MycroftSkill):
                 LOG.debug(f"Skill speak! {data}")
             LOG.debug(msg_to_emit.msg_type)
 
-            if wait and check_for_signal("neon_speak_api"):
+            if wait and check_for_signal("neon_speak_api", -1):
                 msg_to_emit.data['speak_ident'] = str(time.time())
                 self.bus.wait_for_response(msg_to_emit,
                                            msg_to_emit.data['speak_ident'],

--- a/tests/neon_skill_tests.py
+++ b/tests/neon_skill_tests.py
@@ -35,7 +35,7 @@ import unittest
 from multiprocessing import Event
 from os.path import join
 from threading import Thread
-from time import sleep
+from time import sleep, time
 
 import pytest
 from mock.mock import patch, MagicMock
@@ -739,7 +739,45 @@ class PatchedMycroftSkillTests(unittest.TestCase):
         message.context.pop('destination')
         self.assertEqual(message.context, msg.context)
 
-    # TODO: test wait with/without `speak_bus_api`
+    def test_speak_wait(self):
+        from neon_utils.signal_utils import create_signal, check_for_signal, \
+            wait_for_signal_clear
+        create_signal("neon_speak_api")
+        message: Message = None
+
+        def on_speak(msg):
+            def handler(msg):
+                nonlocal message
+                message = msg
+                sleep(1)
+                skill.bus.emit(Message(msg.data.get('speak_ident')))
+                sleep(1)
+                check_for_signal("isSpeaking")
+            Thread(target=handler, args=(msg,), daemon=True).start()
+
+        skill = get_test_mycroft_skill(
+            {"speak": on_speak})
+
+        # Test wait with speak API
+        speak_time = time()
+        create_signal("isSpeaking")  # Mock signal create
+        skill.speak('test', wait=True)
+        # Make sure we actually waited
+        self.assertGreaterEqual(time(), speak_time + 1)
+        self.assertLessEqual(time(), speak_time + 2)
+        self.assertTrue(check_for_signal("neon_speak_api", -1))
+        self.assertIsInstance(message, Message)
+        self.assertIsInstance(message.data['speak_ident'], str)
+
+        wait_for_signal_clear('isSpeaking')  # Wait for first test to finish
+        # Test wait with signals
+        self.assertTrue(check_for_signal("neon_speak_api"))
+        speak_time = time()
+        create_signal("isSpeaking")  # Mock signal create
+        skill.speak('test', wait=True)
+        # Make sure we actually waited
+        self.assertGreaterEqual(time(), speak_time + 2)
+        self.assertFalse(check_for_signal("neon_speak_api", -1))
 
     # TODO: Test settings load
 

--- a/tests/neon_skill_tests.py
+++ b/tests/neon_skill_tests.py
@@ -347,6 +347,7 @@ class PatchedMycroftSkillTests(unittest.TestCase):
                                    "username": "invalid_converse_user"})
 
         skill = get_test_mycroft_skill({"speak": handle_speak})
+        skill._get_response_timeout = 5
         t = Thread(target=skill_response_thread,
                    args=(skill, valid_message.context["username"]),
                    daemon=True)
@@ -559,6 +560,8 @@ class PatchedMycroftSkillTests(unittest.TestCase):
         self.assertEqual(test_results[valid_message.context["username"]],
                          valid_message.data["utterances"][0])
 
+# TODO: test get_response with `speak_bus_api`
+
     def test_speak_simple_valid(self):
         handle_speak = Mock()
         utterance = "test to speak"
@@ -735,6 +738,8 @@ class PatchedMycroftSkillTests(unittest.TestCase):
         message.context.pop('source')
         message.context.pop('destination')
         self.assertEqual(message.context, msg.context)
+
+    # TODO: test wait with/without `speak_bus_api`
 
     # TODO: Test settings load
 


### PR DESCRIPTION
Update `get_response` to better support event-based speaking checks
Goes with https://github.com/NeonGeckoCom/neon_audio/pull/91