### PR TITLE
Fix log settings init

### DIFF
--- a/neon_utils/log_utils.py
+++ b/neon_utils/log_utils.py
@@ -198,6 +198,7 @@ def init_log(config: dict = None) -> type(LOG):
     _log_level = _cfg.get("log_level", "INFO")
     _logs_conf = _cfg.get("logs") or {}
     _logs_conf["level"] = _log_level
+    LOG.debug(f"Initializing logger with: {_logs_conf}")
     LOG.init(_logs_conf)  # read log level from config
     LOG.name = _logs_conf.get("name") or "neon-utils"
     overrides = _logs_conf.get('level_overrides') or {}

--- a/neon_utils/log_utils.py
+++ b/neon_utils/log_utils.py
@@ -198,9 +198,9 @@ def init_log(config: dict = None) -> type(LOG):
     _log_level = _cfg.get("log_level", "INFO")
     _logs_conf = _cfg.get("logs") or {}
     _logs_conf["level"] = _log_level
+    LOG.name = _logs_conf.get("name") or "neon-utils"
     LOG.debug(f"Initializing logger with: {_logs_conf}")
     LOG.init(_logs_conf)  # read log level from config
-    LOG.name = _logs_conf.get("name") or "neon-utils"
     overrides = _logs_conf.get('level_overrides') or {}
     for log in overrides.get("error") or []:
         logging.getLogger(log).setLevel(logging.ERROR)

--- a/neon_utils/log_utils.py
+++ b/neon_utils/log_utils.py
@@ -188,17 +188,20 @@ def init_log_for_module(service: ServiceLog = ServiceLog.OTHER,
               "level": level})
 
 
-def init_log(config: dict = None) -> type(LOG):
+def init_log(config: dict = None, log_name: str = None) -> type(LOG):
     """
     Initialize `LOG` with configuration params. Should be called once on module
     init.
+    :param config: Configuration to apply to LOG
+    :param log_name: Optional LOG.name override, else use Configuration or default
+    :returns: LOG singleton
     """
     from ovos_config.config import Configuration
     _cfg = config or Configuration()
     _log_level = _cfg.get("log_level", "INFO")
     _logs_conf = _cfg.get("logs") or {}
     _logs_conf["level"] = _log_level
-    LOG.name = _logs_conf.get("name") or "neon-utils"
+    LOG.name = log_name or _logs_conf.get("name") or "neon-utils"
     LOG.debug(f"Initializing logger with: {_logs_conf}")
     LOG.init(_logs_conf)  # read log level from config
     overrides = _logs_conf.get('level_overrides') or {}

--- a/neon_utils/log_utils.py
+++ b/neon_utils/log_utils.py
@@ -33,7 +33,6 @@ from datetime import datetime, timedelta
 from enum import Enum
 from os.path import isdir
 from typing import Optional, Union
-from ovos_config.config import Configuration
 from ovos_utils.xdg_utils import xdg_data_home
 from ovos_utils.log import LOG
 
@@ -41,11 +40,13 @@ from ovos_utils.log import LOG
 _LOG = None
 
 
-def get_log_dir() -> str:
+def get_log_dir(config: dict = None) -> str:
     """
     Get log directory from configuration or default path, create if not exists
     """
-    log_dir = os.path.expanduser(dict(Configuration()).get("log_dir") or
+    from ovos_config.config import Configuration
+    config = config or Configuration()
+    log_dir = os.path.expanduser(config.get("log_dir") or
                                  os.path.join(xdg_data_home(), "neon", "logs"))
     if not isdir(log_dir):
         os.makedirs(log_dir, exist_ok=True)
@@ -192,6 +193,7 @@ def init_log(config: dict = None) -> type(LOG):
     Initialize `LOG` with configuration params. Should be called once on module
     init.
     """
+    from ovos_config.config import Configuration
     _cfg = config or Configuration()
     _log_level = _cfg.get("log_level", "INFO")
     _logs_conf = _cfg.get("logs") or {}

--- a/neon_utils/logger.py
+++ b/neon_utils/logger.py
@@ -27,4 +27,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from ovos_utils.log import LOG
+
+if LOG.name == 'OVOS':
+    LOG.name = 'neon-utils'
 # TODO: Deprecate this backwards-compat import in 2.0.0

--- a/neon_utils/logger.py
+++ b/neon_utils/logger.py
@@ -29,3 +29,4 @@
 from neon_utils.log_utils import get_log
 
 LOG = get_log()
+# TODO: Deprecate this backwards-compat object in 2.0.0

--- a/neon_utils/logger.py
+++ b/neon_utils/logger.py
@@ -26,10 +26,6 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import logging
-from ovos_utils.log import LOG
+from neon_utils.log_utils import get_log
 
-LOG.name = "neon-utils"
-
-logging.getLogger("filelock").setLevel(logging.WARNING)
-logging.getLogger("botocore").setLevel(logging.WARNING)
+LOG = get_log()

--- a/neon_utils/logger.py
+++ b/neon_utils/logger.py
@@ -26,7 +26,5 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from neon_utils.log_utils import get_log
-
-LOG = get_log()
-# TODO: Deprecate this backwards-compat object in 2.0.0
+from ovos_utils.log import LOG
+# TODO: Deprecate this backwards-compat import in 2.0.0

--- a/tests/license_tests.py
+++ b/tests/license_tests.py
@@ -11,7 +11,8 @@ license_overrides = {
     'pyxdg': 'GPL-2.0',
     'ptyprocess': 'ISC license',
     'psutil': 'BSD3',
-    "python-dateutil": "Apache-2.0"
+    "python-dateutil": "Apache-2.0",
+    "idna": "BSD3"
 }
 # explicitly allow these packages that would fail otherwise
 whitelist = []

--- a/tests/log_util_tests.py
+++ b/tests/log_util_tests.py
@@ -46,10 +46,12 @@ LOG_PATH = os.path.join(ROOT_DIR, "tests", "log_files")
 class LogUtilTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
+        os.environ['XDG_CONFIG_HOME'] = '/tmp'
         os.makedirs(LOG_PATH, exist_ok=True)
 
     @classmethod
     def tearDownClass(cls) -> None:
+        os.environ.pop('XDG_CONFIG_HOME')
         shutil.rmtree(LOG_PATH)
 
     def test_get_log_file(self):
@@ -202,7 +204,6 @@ class LogUtilTests(unittest.TestCase):
         self.assertEqual(NLOG, log)
 
     def test_get_log(self):
-        os.environ['XDG_CONFIG_HOME'] = '/tmp'
         from neon_utils.log_utils import get_log
         from ovos_utils.log import LOG as OLOG
         from neon_utils.log_utils import LOG as NLOG

--- a/tests/log_util_tests.py
+++ b/tests/log_util_tests.py
@@ -174,6 +174,40 @@ class LogUtilTests(unittest.TestCase):
         log_dir = get_log_dir()
         self.assertTrue(isdir(log_dir))
 
+    def test_init_log(self):
+        from neon_utils.log_utils import init_log
+        config = {'log_level': 'DEBUG',
+                  "logs": {
+                      "name": "neon-utils"
+                  }}
+        log = init_log(config)
+        self.assertEqual(log.name, "neon-utils")
+        self.assertEqual(log.level, "DEBUG")
+        from ovos_utils.log import LOG as OLOG
+        from neon_utils.logger import LOG as NLOG
+        self.assertEqual(OLOG, log)
+        self.assertEqual(NLOG, log)
+
+        config['log_level'] = 'INFO'
+        config['logs']['name'] = 'test'
+        config['logs']['level_overrides'] = {
+            'error': ['filelock']
+        }
+        new_log = init_log(config)
+        self.assertEqual(log, new_log)
+        self.assertEqual(log.name, "test")
+        self.assertEqual(log.level, "INFO")
+        self.assertEqual(logging.getLogger('filelock').level, logging.ERROR)
+        self.assertEqual(OLOG, log)
+        self.assertEqual(NLOG, log)
+
+    def test_get_log(self):
+        from neon_utils.log_utils import get_log
+        from ovos_utils.log import LOG as OLOG
+        from neon_utils.log_utils import LOG as NLOG
+        self.assertEqual(get_log(), OLOG)
+        self.assertEqual(get_log(), NLOG)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/log_util_tests.py
+++ b/tests/log_util_tests.py
@@ -202,6 +202,7 @@ class LogUtilTests(unittest.TestCase):
         self.assertEqual(NLOG, log)
 
     def test_get_log(self):
+        os.environ['XDG_CONFIG_HOME'] = '/tmp'
         from neon_utils.log_utils import get_log
         from ovos_utils.log import LOG as OLOG
         from neon_utils.log_utils import LOG as NLOG


### PR DESCRIPTION
Adds method to initialize `LOG` singleton. Mostly duplicates init that normally happens [in ovos-core](https://github.com/OpenVoiceOS/ovos-core/blob/dev/mycroft/__init__.py)