### PR TITLE
Remove default user location config

### DIFF
--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -902,7 +902,8 @@ def get_mycroft_compatible_location(location: dict) -> dict:
     # except Exception as e:
     #     LOG.exception(e)
     #     parsed_location = None
-    if location.get("country", '').lower() == "united states":
+    if location.get("country") and \
+            location.get("country").lower() == "united states":
         location["country_code"] = "us"
 
     if location.get('utc'):
@@ -912,6 +913,8 @@ def get_mycroft_compatible_location(location: dict) -> dict:
             offset = float(location["utc"])
         except ValueError:
             offset = 0.0
+    else:
+        offset = 0.0
 
     try:
         lat = float(lat)

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -886,6 +886,9 @@ def get_mycroft_compatible_location(location: dict) -> dict:
     :returns: dict formatted to match mycroft.conf spec
     """
     from neon_utils.parse_utils import clean_quotes
+    if not (location['lat'] and location['lng']):
+        LOG.debug('Neon config empty, return core value')
+        return _safe_mycroft_config().get('location')
     try:
         lat = clean_quotes(location['lat'])
         lng = clean_quotes(location['lng'])

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -902,15 +902,16 @@ def get_mycroft_compatible_location(location: dict) -> dict:
     # except Exception as e:
     #     LOG.exception(e)
     #     parsed_location = None
-    if location["country"].lower() == "united states":
+    if location.get("country", '').lower() == "united states":
         location["country_code"] = "us"
 
-    try:
-        offset = float(clean_quotes(location["utc"]))
-    except TypeError:
-        offset = float(location["utc"])
-    except ValueError:
-        offset = 0.0
+    if location.get('utc'):
+        try:
+            offset = float(clean_quotes(location["utc"]))
+        except TypeError:
+            offset = float(location["utc"])
+        except ValueError:
+            offset = 0.0
 
     try:
         lat = float(lat)

--- a/neon_utils/configuration_utils.py
+++ b/neon_utils/configuration_utils.py
@@ -886,7 +886,8 @@ def get_mycroft_compatible_location(location: dict) -> dict:
     :returns: dict formatted to match mycroft.conf spec
     """
     from neon_utils.parse_utils import clean_quotes
-    if not (location['lat'] and location['lng']):
+    if not any((location['lat'], location['lng'],
+                location['city'], location['tz'])):
         LOG.debug('Neon config empty, return core value')
         return _safe_mycroft_config().get('location')
     try:

--- a/neon_utils/default_configurations/default_user_conf.yml
+++ b/neon_utils/default_configurations/default_user_conf.yml
@@ -40,13 +40,13 @@ units:
   # imperial, metric
 
 location:
-  lat: '47.4799078'
-  lng: '-122.2034496'
-  city: Renton
-  state: Washington
-  country: United States
-  tz: America/Los_Angeles
-  utc: '-8.0'
+  lat:
+  lng:
+  city:
+  state:
+  country:
+  tz:
+  utc:
 
 response_mode:
   speed_mode: quick

--- a/neon_utils/skills/mycroft_skill.py
+++ b/neon_utils/skills/mycroft_skill.py
@@ -60,6 +60,10 @@ class PatchedMycroftSkill(MycroftSkill):
 
     @property
     def location(self):
+        """
+        Backwards-compatible location property. Returns core location config if
+        user location isn't specified.
+        """
         return get_mycroft_compatible_location(get_user_prefs()["location"])
 
     @property

--- a/tests/configuration_util_tests.py
+++ b/tests/configuration_util_tests.py
@@ -673,6 +673,33 @@ class ConfigurationUtilTests(unittest.TestCase):
         with self.assertRaises(KeyError):
             get_mycroft_compatible_location(user_config.content)
 
+        # Default mycroft.conf
+        location = get_mycroft_compatible_location(user_config["location"])
+
+        self.assertIsInstance(location["city"]["name"], str)
+        self.assertIsInstance(location["city"]["code"], str)
+        self.assertIsInstance(location["city"]["state"]["name"], str)
+        self.assertIsInstance(location["city"]["state"]["code"], str)
+        self.assertIsInstance(location["city"]["state"]["country"]["name"], str)
+        self.assertIsInstance(location["city"]["state"]["country"]["code"], str)
+
+        self.assertIsInstance(location["timezone"]["code"], str)
+        self.assertIsInstance(location["coordinate"]["latitude"], float)
+        self.assertIsInstance(location["coordinate"]["longitude"], float)
+        self.assertIsInstance(location["timezone"]["name"], str)
+        self.assertIsInstance(location["timezone"]["offset"], (float, int))
+        self.assertEqual(location["timezone"]["dstOffset"], 3600000)
+
+        # Valid user configured location
+        user_config['location'] = {
+            'lat': '47.4799078',
+            'lng': '-122.2034496',
+            'city': 'Renton',
+            'state': 'Washington',
+            'country': 'United States',
+            'tz': 'America/Los_Angeles',
+            'utc': '-8.0'
+        }
         location = get_mycroft_compatible_location(user_config["location"])
         self.assertEqual(location["city"]["name"],
                          user_config["location"]["city"])
@@ -701,6 +728,7 @@ class ConfigurationUtilTests(unittest.TestCase):
         real_lat = user_config["location"]["lat"]
         real_lon = user_config["location"]["lng"]
 
+        # Quoted strings in location
         user_config["location"]["lat"] = f'"{real_lat}"'
         user_config["location"]["lng"] = f'"{real_lon}"'
         user_config["location"]["utc"] = '-8.0'
@@ -724,6 +752,7 @@ class ConfigurationUtilTests(unittest.TestCase):
         location = get_mycroft_compatible_location(user_config["location"])
         self.assertIsInstance(location["timezone"]["offset"], float)
 
+        # Float
         user_config["location"]["utc"] = 8.0
         location = get_mycroft_compatible_location(user_config["location"])
         self.assertIsInstance(location["timezone"]["offset"], float)

--- a/tests/configuration_util_tests.py
+++ b/tests/configuration_util_tests.py
@@ -761,6 +761,25 @@ class ConfigurationUtilTests(unittest.TestCase):
         location = get_mycroft_compatible_location(user_config["location"])
         self.assertIsInstance(location["timezone"]["offset"], float)
 
+        # Incomplete user locations
+        location = {
+            'lat': None,
+            'lng': None,
+            'city': None,
+            'state': None,
+            'country': None,
+            'tz': None,
+            'utc': None
+        }
+        location['tz'] = 'America/Los_Angeles'
+        self.assertIsInstance(get_mycroft_compatible_location(location), dict)
+        location['tz'] = None
+        location['city'] = 'Renton'
+        self.assertIsInstance(get_mycroft_compatible_location(location), dict)
+        location['city'] = None
+        location['lat'] = '47.4799078'
+        location['lng'] = '-122.2034496'
+        self.assertIsInstance(get_mycroft_compatible_location(location), dict)
         shutil.move(old_user_info, ngi_user_info)
 
     def test_get_user_config_from_mycroft_conf(self):


### PR DESCRIPTION
Update `mycroft_compatible_location` method to fall back to default core config if user location isn't specified. Also adds unit tests for incomplete location configs