### PR TITLE
Make MQ dependencies network optional extras

### DIFF
--- a/neon_utils/mq_utils.py
+++ b/neon_utils/mq_utils.py
@@ -29,11 +29,15 @@
 import logging
 import uuid
 
-from threading import Event
-from pika.channel import Channel
-from pika.exceptions import ProbableAccessDeniedError, StreamLostError
-from neon_mq_connector.connector import MQConnector
-from ovos_config.config import Configuration
+try:
+    from threading import Event
+    from pika.channel import Channel
+    from pika.exceptions import ProbableAccessDeniedError, StreamLostError
+    from neon_mq_connector.connector import MQConnector
+    from ovos_config.config import Configuration
+except ImportError:
+    raise ImportError("MQ dependencies not available,"
+                      " pip install neon-utils[network]")
 
 from neon_utils.logger import LOG
 from neon_utils.socket_utils import b64_to_dict

--- a/requirements/network.txt
+++ b/requirements/network.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4~=4.9
 lxml~=4.5
 netifaces~=0.10
+neon_mq_connector~=0.2,>=0.5.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,6 +6,5 @@ nltk~=3.5
 pyyaml~=5.4
 ovos-lingua-franca~=0.4
 ovos_utils~=0.0.6
-neon_mq_connector~=0.2,>=0.5.1
 geopy~=2.1
 ovos-config~=0.0,>=0.0.3


### PR DESCRIPTION
Move MQ Connector dependency to `network` extra to troubleshoot circular dependency bugs in version resolution