### PR TITLE
Get response from validated value

### DIFF
--- a/neon_utils/skills/mycroft_skill.py
+++ b/neon_utils/skills/mycroft_skill.py
@@ -297,12 +297,14 @@ class PatchedMycroftSkill(MycroftSkill):
                     LOG.info("No user response")
                     return None
             else:
-                if validator(response):
-                    return response
-
                 # catch user saying 'cancel'
                 if is_cancel(response):
                     return None
+                validated = validator(response)
+                # returns the validated value or the response
+                # (backwards compat)
+                if validated is not False and validated is not None:
+                    return response if validated is True else validated
 
             num_fails += 1
             if 0 < num_retries < num_fails:


### PR DESCRIPTION
Problem: the validator as is returns the response. This is cumbersome, because sometimes you have to do things twice.
As a simple example, you want to ensure a datetime from a response you have to extract it once in the validator and the second time in the calling function to get the datetime.

This addition will optionally return the validated value if not `True` is returned from the validator (if `True` the original response; backwards compat)

If the validated value is `False` or `None` it depends on `num_retries` how to proceed. (if to ask again or return None)
