### PR TITLE
Add `chat_handler` decorator with bus registration

### DIFF
--- a/neon_utils/skills/__init__.py
+++ b/neon_utils/skills/__init__.py
@@ -34,3 +34,14 @@ from .instructor_skill import InstructorSkill
 from .kiosk_skill import KioskSkill
 from .neon_skill import NeonSkill
 from .mycroft_skill import PatchedMycroftSkill
+
+
+def chat_handler(name):
+    """
+    Decorator to mark a method as a chatbot endpoint
+    """
+
+    def real_decorator(func):
+        func.chat_handler = name
+        return func
+    return real_decorator

--- a/neon_utils/skills/neon_skill.py
+++ b/neon_utils/skills/neon_skill.py
@@ -450,7 +450,7 @@ class NeonSkill(MycroftSkill):
         return
 
     def register_chat_handler(self, name: str, method: callable):
-        self.add_event(f'chat.{self.skill_id}.{name}', method)
+        self.add_event(f'chat.{name}', method)
 
     def _register_decorated(self):
         for attr_name in get_non_properties(self):

--- a/neon_utils/skills/neon_skill.py
+++ b/neon_utils/skills/neon_skill.py
@@ -460,7 +460,8 @@ class NeonSkill(MycroftSkill):
 
         def wrapped_handler(message):
             response = method(message)
-            self.bus.emit(message.response(data={'response': response}))
+            self.bus.emit(message.response(data={'response': response},
+                                           context={'skill_id': self.skill_id}))
 
         self.add_event(f'chat.{name}', wrapped_handler)
         msg = dig_for_message() or Message("",

--- a/tests/neon_skill_tests.py
+++ b/tests/neon_skill_tests.py
@@ -271,6 +271,33 @@ class KioskSkillTests(unittest.TestCase):
         self.assertEqual(self.skill._active_users, dict())
 
 
+class ChatSkillTests(unittest.TestCase):
+    def test_skill_init(self):
+        msg: Message = None
+
+        def handle_register(message):
+            nonlocal msg
+            msg = message
+
+        BUS.once("register_chat_handler", handle_register)
+
+        # Test decorator registration
+        skill = create_skill(TestChatSkill)
+        self.assertIsInstance(msg, Message)
+        self.assertEqual(msg.data['name'], "Test Bot")
+        self.assertEqual(msg.context['skill_id'], skill.skill_id)
+
+        # Test decorated method
+        test_message = Message("chat.Test Bot", {"test_response": "nothing"},
+                               {'test': True})
+        resp = BUS.wait_for_response(test_message)
+        self.assertEqual(resp.msg_type, f'{test_message.msg_type}.response')
+        self.assertEqual(resp.data,
+                         {'response': test_message.data['test_response']})
+        self.assertEqual(resp.context, {'test': True,
+                                        'skill_id': skill.skill_id})
+
+
 class PatchedMycroftSkillTests(unittest.TestCase):
     def test_get_response_simple(self):
         def handle_speak(_):

--- a/tests/skills/__init__.py
+++ b/tests/skills/__init__.py
@@ -114,6 +114,17 @@ class TestMycroftFallbackSkill(FallbackSkill):
         super().__init__(name="TestSkill")
 
 
+class TestChatSkill(NeonSkill):
+    from neon_utils.skills import chat_handler
+
+    def __init__(self):
+        super().__init__(name="Test Neon Chat Skill")
+
+    @chat_handler("Test Bot")
+    def handle_chat_message(self, message: Message):
+        return message.data.get("test_response")
+
+
 class TestKioskSkill(KioskSkill):
     def __init__(self):
         super(TestKioskSkill, self).__init__()


### PR DESCRIPTION
Adds a `chat_handler` decorator to expose a specific method via a messagebus event. An incoming message is treated as an utterance, so this may be used on a regular intent handler

i.e.:

```python
@chat_handler('wolfram')
def handle_chat_message(message: Message):
    utterance = message.data.get('utterance')
    self.speak('response')
```

A request would look like: `Message("chat.wolfram", {"utterance": "hello"}, {})