### PR TITLE
Fix relative path references in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,11 @@ import setuptools
 from os import path, environ
 
 
+BASE_PATH = path.abspath(path.dirname(__file__))
+
+
 def get_requirements(requirements_filename: str):
-    requirements_file = path.join(path.abspath(path.dirname(__file__)),
-                                  "requirements", requirements_filename)
+    requirements_file = path.join(BASE_PATH, "requirements", requirements_filename)
     with open(requirements_file, 'r', encoding='utf-8') as r:
         requirements = r.readlines()
     requirements = [r.strip() for r in requirements
@@ -45,10 +47,10 @@ def get_requirements(requirements_filename: str):
     return requirements
 
 
-with open("README.md", "r") as f:
+with open(path.join(BASE_PATH, "README.md"), "r") as f:
     long_description = f.read()
 
-with open("./version.py", "r", encoding="utf-8") as v:
+with open(path.join(BASE_PATH, "version.py"), "r", encoding="utf-8") as v:
     for line in v.readlines():
         if line.startswith("__version__"):
             if '"' in line:


### PR DESCRIPTION
# Description
Fix setup.py to use file-relative paths instead of cwd-relative paths

# Issues
Fixes bug discovered in #414 

# Other Notes
Relates to https://github.com/NeonGeckoCom/.github/pull/6