### PR TITLE
Update `secondary_langs` skill property

### DIFF
--- a/neon_utils/skills/mycroft_skill.py
+++ b/neon_utils/skills/mycroft_skill.py
@@ -64,10 +64,6 @@ class PatchedMycroftSkill(MycroftSkill):
         """
         return get_mycroft_compatible_location(get_user_prefs()["location"])
 
-    @property
-    def _secondary_langs(self):
-        return get_user_prefs()["speech"]["alt_languages"]
-
     def _init_settings(self):
         """
         Extends the default method to handle settingsmeta defaults locally


### PR DESCRIPTION
# Description
Remove `secondary_langs` property override since this is core-oriented and not user-oriented for skills

# Issues
Resolves [skill failures](https://github.com/NeonGeckoCom/skill-about/actions/runs/4265209510/jobs/7424271263)

# Other Notes
There is a user-oriented secondary language config, but it is not relevant here, only for STT. For skills, supported/secondary languages are determined by the skill